### PR TITLE
feat: Add support for using SuperTokens with app extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2022-10-17
+
+- Adds support for using SuperTokens across app extensions (using App Groups)
+
 ## [0.0.1] - 2022-10-12
 
 - Inial Release

--- a/SuperTokensIOS.podspec
+++ b/SuperTokensIOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SuperTokensIOS'
-  s.version          = "0.0.1"
+  s.version          = "0.1.0"
   s.summary          = 'SuperTokens SDK for using login and session management functionality in iOS apps'
 
 # This description is used to generate tags and improve search results.

--- a/SuperTokensIOS/Classes/AntiCSRF.swift
+++ b/SuperTokensIOS/Classes/AntiCSRF.swift
@@ -37,7 +37,7 @@ internal class AntiCSRF {
         }
         
         if AntiCSRF.antiCSRFInfo == nil {
-            let userDefaults = AntiCSRF.getUserDefaults()
+            let userDefaults = Utils.getUserDefaults()
             let antiCSRFToken = userDefaults.string(forKey: AntiCSRF.antiCSRFUserDefaultsKey)
             if ( antiCSRFToken == nil ) {
                 return nil
@@ -58,7 +58,7 @@ internal class AntiCSRF {
             return;
         }
         
-        let userDefaults = AntiCSRF.getUserDefaults()
+        let userDefaults = Utils.getUserDefaults()
         userDefaults.set(antiCSRFToken, forKey: AntiCSRF.antiCSRFUserDefaultsKey)
         userDefaults.synchronize()
         
@@ -66,13 +66,9 @@ internal class AntiCSRF {
     }
     
     internal static func removeToken() {
-        let userDefaults = AntiCSRF.getUserDefaults()
+        let userDefaults = Utils.getUserDefaults()
         userDefaults.removeObject(forKey: AntiCSRF.antiCSRFUserDefaultsKey)
         userDefaults.synchronize()
         AntiCSRF.antiCSRFInfo = nil
-    }
-    
-    private static func getUserDefaults() -> UserDefaults {
-        return UserDefaults.standard
     }
 }

--- a/SuperTokensIOS/Classes/FrontToken.swift
+++ b/SuperTokensIOS/Classes/FrontToken.swift
@@ -15,7 +15,7 @@ internal class FrontToken {
     
     private static func getFrontTokenFromStorage() -> String? {
         if tokenInMemory == nil {
-            tokenInMemory = getUserDefaults().string(forKey: userDefaultsKey)
+            tokenInMemory = Utils.getUserDefaults().string(forKey: userDefaultsKey)
         }
         
         return tokenInMemory
@@ -71,7 +71,7 @@ internal class FrontToken {
     }
     
     private static func setFrontTokenToStorage(frontToken: String?) {
-        getUserDefaults().set(frontToken, forKey: userDefaultsKey)
+        Utils.getUserDefaults().set(frontToken, forKey: userDefaultsKey)
         tokenInMemory = frontToken
     }
     
@@ -106,7 +106,7 @@ internal class FrontToken {
     }
     
     private static func removeTokenFromStorage() {
-        getUserDefaults().removeObject(forKey: userDefaultsKey)
+        Utils.getUserDefaults().removeObject(forKey: userDefaultsKey)
         tokenInMemory = nil
     }
     
@@ -120,9 +120,5 @@ internal class FrontToken {
         }
         
         executionSemaphore.wait()
-    }
-    
-    private static func getUserDefaults() -> UserDefaults {
-        return UserDefaults.standard
     }
 }

--- a/SuperTokensIOS/Classes/IdRefreshToken.swift
+++ b/SuperTokensIOS/Classes/IdRefreshToken.swift
@@ -28,7 +28,7 @@ internal class IdRefreshToken {
     
     internal static func getToken() -> String? {
         if ( IdRefreshToken.idRefreshInMemory == nil ) {
-            idRefreshInMemory = IdRefreshToken.getUserDefaults().string(forKey: IdRefreshToken.idRefreshUserDefaultsKey)
+            idRefreshInMemory = Utils.getUserDefaults().string(forKey: IdRefreshToken.idRefreshUserDefaultsKey)
         }
         if (IdRefreshToken.idRefreshInMemory != nil) {
             let splitted = IdRefreshToken.idRefreshInMemory!.components(separatedBy: ";");
@@ -52,7 +52,7 @@ internal class IdRefreshToken {
             if expiry < currentTime {
                 IdRefreshToken.removeToken()
             } else {
-                let userDefaults = IdRefreshToken.getUserDefaults()
+                let userDefaults = Utils.getUserDefaults()
                 userDefaults.set(newIdRefreshToken, forKey: IdRefreshToken.idRefreshUserDefaultsKey)
                 userDefaults.synchronize()
                 IdRefreshToken.idRefreshInMemory = newIdRefreshToken
@@ -73,13 +73,9 @@ internal class IdRefreshToken {
     }
     
     internal static func removeToken() {
-        let userDefaults = IdRefreshToken.getUserDefaults()
+        let userDefaults = Utils.getUserDefaults()
         userDefaults.removeObject(forKey: IdRefreshToken.idRefreshUserDefaultsKey)
         userDefaults.synchronize()
         IdRefreshToken.idRefreshInMemory = nil
-    }
-    
-    private static func getUserDefaults() -> UserDefaults {
-        return UserDefaults.standard
     }
 }

--- a/SuperTokensIOS/Classes/SuperTokens.swift
+++ b/SuperTokensIOS/Classes/SuperTokens.swift
@@ -44,12 +44,12 @@ public class SuperTokens {
         SuperTokens.isInitCalled = false
     }
     
-    public static func initialize(apiDomain: String, apiBasePath: String? = nil, sessionExpiredStatusCode: Int? = nil, cookieDomain: String? = nil, eventHandler: ((EventType) -> Void)? = nil, preAPIHook: ((APIAction, URLRequest) -> URLRequest)? = nil, postAPIHook: ((APIAction, URLRequest, URLResponse?) -> Void)? = nil) throws {
+    public static func initialize(apiDomain: String, apiBasePath: String? = nil, sessionExpiredStatusCode: Int? = nil, cookieDomain: String? = nil, userDefaultsSuiteName: String? = nil, eventHandler: ((EventType) -> Void)? = nil, preAPIHook: ((APIAction, URLRequest) -> URLRequest)? = nil, postAPIHook: ((APIAction, URLRequest, URLResponse?) -> Void)? = nil) throws {
         if SuperTokens.isInitCalled {
             return;
         }
         
-        SuperTokens.config = try NormalisedInputType.normaliseInputType(apiDomain: apiDomain, apiBasePath: apiBasePath, sessionExpiredStatusCode: sessionExpiredStatusCode, cookieDomain: cookieDomain, eventHandler: eventHandler, preAPIHook: preAPIHook, postAPIHook: postAPIHook)
+        SuperTokens.config = try NormalisedInputType.normaliseInputType(apiDomain: apiDomain, apiBasePath: apiBasePath, sessionExpiredStatusCode: sessionExpiredStatusCode, cookieDomain: cookieDomain, eventHandler: eventHandler, preAPIHook: preAPIHook, postAPIHook: postAPIHook, userDefaultsSuiteName: userDefaultsSuiteName)
         
         guard let _config: NormalisedInputType = SuperTokens.config else {
             throw SuperTokensError.initError(message: "Error initialising SuperTokens")

--- a/SuperTokensIOS/Classes/Utils.swift
+++ b/SuperTokensIOS/Classes/Utils.swift
@@ -15,8 +15,9 @@ class NormalisedInputType {
     var eventHandler: (EventType) -> Void
     var preAPIHook: (APIAction, URLRequest) -> URLRequest
     var postAPIHook: (APIAction, URLRequest, URLResponse?) -> Void
+    var userDefaultsSuiteName: String?
     
-    init(apiDomain: String, apiBasePath: String, sessionExpiredStatusCode: Int, cookieDomain: String?, eventHandler: @escaping (EventType) -> Void, preAPIHook: @escaping (APIAction, URLRequest) -> URLRequest, postAPIHook: @escaping (APIAction, URLRequest, URLResponse?) -> Void) {
+    init(apiDomain: String, apiBasePath: String, sessionExpiredStatusCode: Int, cookieDomain: String?, eventHandler: @escaping (EventType) -> Void, preAPIHook: @escaping (APIAction, URLRequest) -> URLRequest, postAPIHook: @escaping (APIAction, URLRequest, URLResponse?) -> Void, userDefaultsSuiteName: String?) {
         self.apiDomain = apiDomain
         self.apiBasePath = apiBasePath
         self.sessionExpiredStatusCode = sessionExpiredStatusCode
@@ -24,6 +25,8 @@ class NormalisedInputType {
         self.eventHandler = eventHandler
         self.preAPIHook = preAPIHook
         self.postAPIHook = postAPIHook
+        self.userDefaultsSuiteName = userDefaultsSuiteName
+
     }
     
     internal static func sessionScopeHelper(sessionScope: String) throws -> String {
@@ -68,7 +71,7 @@ class NormalisedInputType {
         return noDotNormalised
     }
     
-    internal static func normaliseInputType(apiDomain: String, apiBasePath: String?, sessionExpiredStatusCode: Int?, cookieDomain: String?, eventHandler: ((EventType) -> Void)?, preAPIHook: ((APIAction, URLRequest) -> URLRequest)?, postAPIHook: ((APIAction, URLRequest, URLResponse?) -> Void)?) throws -> NormalisedInputType {
+    internal static func normaliseInputType(apiDomain: String, apiBasePath: String?, sessionExpiredStatusCode: Int?, cookieDomain: String?, eventHandler: ((EventType) -> Void)?, preAPIHook: ((APIAction, URLRequest) -> URLRequest)?, postAPIHook: ((APIAction, URLRequest, URLResponse?) -> Void)?, userDefaultsSuiteName: String?) throws -> NormalisedInputType {
         let _apiDomain = try NormalisedURLDomain(url: apiDomain)
         var _apiBasePath = try NormalisedURLPath(input: "/auth")
         
@@ -107,7 +110,7 @@ class NormalisedInputType {
             _postApiHook = postAPIHook!
         }
         
-        return NormalisedInputType(apiDomain: _apiDomain.getAsStringDangerous(), apiBasePath: _apiBasePath.getAsStringDangerous(), sessionExpiredStatusCode: _sessionExpiredStatusCode, cookieDomain: _cookieDomain, eventHandler: _eventHandler, preAPIHook: _preAPIHook, postAPIHook: _postApiHook)
+        return NormalisedInputType(apiDomain: _apiDomain.getAsStringDangerous(), apiBasePath: _apiBasePath.getAsStringDangerous(), sessionExpiredStatusCode: _sessionExpiredStatusCode, cookieDomain: _cookieDomain, eventHandler: _eventHandler, preAPIHook: _preAPIHook, postAPIHook: _postApiHook, userDefaultsSuiteName: userDefaultsSuiteName)
     }
 }
 
@@ -155,6 +158,18 @@ internal class Utils {
         let regex: String = "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
         
         return input.matches(regex: regex)
+    }
+    
+    internal static func getUserDefaults() -> UserDefaults {
+        if let _suiteName: String = SuperTokens.config!.userDefaultsSuiteName {
+            if let _userDefaultsWithSuiteName: UserDefaults = UserDefaults(suiteName: _suiteName) {
+                return _userDefaultsWithSuiteName
+            } else {
+                print("SuperTokens: Could not initialise user defaults with suite name '\(_suiteName)', using default")
+            }
+        }
+        
+        return UserDefaults.standard
     }
 }
 

--- a/SuperTokensIOS/Classes/Version.swift
+++ b/SuperTokensIOS/Classes/Version.swift
@@ -9,5 +9,5 @@ import Foundation
 
 internal class Version {
     static let supported_fdi: [String] = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
-    static let sdkVersion = "0.0.1"
+    static let sdkVersion = "0.1.0"
 }


### PR DESCRIPTION
## Summary of change

For applications with multiple extensions, UserDefaults is not shared by default which results in sessions existing for some parts of the app and not for others (because Id refresh token and front token wouldnt exist in that extensions UserDefaults)

The only way to solve this in iOS apps is to add App Groups and use the group name when creating an instance of UserDefaults. This PR adds support for user's to set the UserDefaults suite name when calling SuperTokens.init. SuperTokens will then try to read/write using the shared UserDefaults when possible (falling back to the default if one couldnt be found)

## Related issues
- https://github.com/supertokens/supertokens-ios/issues/30

## Test Plan
Manually tested changes

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [x] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...