### PR TITLE
chore: Add sdk docs generation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ workflows:
   tagged-build:
     jobs:
       - publish:
+          requires:
+            - update-docs
           context:
             - slack-notification
           filters:
@@ -58,8 +60,6 @@ workflows:
             branches:
               ignore: /.*/
       - update-docs:
-          requires:
-              - publish
           context:
               - slack-notification
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,14 @@ jobs:
       - continuation/continue:
           configuration_path: .circleci/config_continue.yml
   update-docs:
-    docker:
-      - image: rishabhpoddar/supertokens_website_sdk_testing_node_16
+    macos:
+      xcode: 14.1.0
     steps:
-      - run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/ # This makes npm use http instead of ssh (required for node 16)
       - checkout
       - run: cd ../ && git clone git@github.com:supertokens/supertokens-backend-website.git
-      - run: (cd .circleci && ./updateDocsInWebsite.sh)
+      - run: gem install jazzy
+      - run: jazzy --output ./docs --podspec SuperTokensIOS.podspec
+      - run: (cd .circleci && ./updateDocsInWebsite)
       - slack/status
 
 workflows:
@@ -56,10 +57,13 @@ workflows:
               only: /dev-v[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
-      # - update-docs:
-      #     context:
-      #         - slack-notification
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
+      - update-docs:
+          requires:
+              - publish
+          context:
+              - slack-notification
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/updateDocsInWebsite
+++ b/.circleci/updateDocsInWebsite
@@ -1,0 +1,27 @@
+#!/bin/bash
+# get current version----------
+version=`cat SuperTokensIOS.podspec | grep -e "s.version          =" -e "s.version="`
+
+while IFS='"' read -ra ADDR; do
+    counter=0
+    for i in "${ADDR[@]}"; do
+        if [ $counter == 1 ]
+        then
+            version=$i
+        fi
+        counter=$(($counter+1))
+    done
+done <<< "$version"
+
+# replace path version with X
+IFS='.' read -r -a array <<< "$version"
+versionFolder="${array[0]}"."${array[1]}".X
+
+(cd ../../supertokens-backend-website && mkdir -p ./app/docs/sdk/docs/ios/${versionFolder})
+cp -r ../docs/* ../../supertokens-backend-website/app/docs/sdk/docs/ios/
+cp -r ../docs/* ../../supertokens-backend-website/app/docs/sdk/docs/ios/${versionFolder}
+
+# push to git
+git config --global user.email "$EMAIL"
+git config --global user.name "$NAME"
+(cd ../../supertokens-backend-website && git add --all && git commit -m"updates ios sdk docs" && git pull && git push && ./releaseDev.sh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2022-10-17
+
+- Added documentation generation
+
 ## [0.1.0] - 2022-10-17
 
 - Adds support for using SuperTokens across app extensions (using App Groups)

--- a/SuperTokensIOS.podspec
+++ b/SuperTokensIOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SuperTokensIOS'
-  s.version          = "0.1.0"
+  s.version          = "0.1.1"
   s.summary          = 'SuperTokens SDK for using login and session management functionality in iOS apps'
 
 # This description is used to generate tags and improve search results.

--- a/SuperTokensIOS/Classes/Version.swift
+++ b/SuperTokensIOS/Classes/Version.swift
@@ -9,5 +9,5 @@ import Foundation
 
 internal class Version {
     static let supported_fdi: [String] = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
-    static let sdkVersion = "0.1.0"
+    static let sdkVersion = "0.1.1"
 }


### PR DESCRIPTION
## Summary of change

- Adds a circleci job to generate and push sdk docs to the documentation website, this job only runs for release tags

## Related issues
- 

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [x] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...