### PR TITLE
fix: Fix interception logic for auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2023-07-10
+
+### Fixes
+
+- Fixed an issue where the Authorization header was getting removed unnecessarily
+
 ## [0.2.2] - 2023-06-06
 
 - Refactors session logic to delete access token and refresh token if the front token is removed. This helps with proxies that strip headers with empty values which would result in the access token and refresh token to persist after signout

--- a/SuperTokensIOS.podspec
+++ b/SuperTokensIOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SuperTokensIOS'
-  s.version          = "0.2.2"
+  s.version          = "0.2.3"
   s.summary          = 'SuperTokens SDK for using login and session management functionality in iOS apps'
 
 # This description is used to generate tags and improve search results.

--- a/SuperTokensIOS/Classes/SuperTokensURLProtocol.swift
+++ b/SuperTokensIOS/Classes/SuperTokensURLProtocol.swift
@@ -64,8 +64,9 @@ public class SuperTokensURLProtocol: URLProtocol {
         // .value is case insensitive
         if let originalAuthorizationHeader = _mutableRequest.value(forHTTPHeaderField: "Authorization") {
             let accessToken = Utils.getTokenForHeaderAuth(tokenType: .access)
+            let refreshToken = Utils.getTokenForHeaderAuth(tokenType: .refresh)
             
-            if accessToken != nil && originalAuthorizationHeader == "Bearer \(accessToken!)" {
+            if accessToken != nil && refreshToken != nil && originalAuthorizationHeader == "Bearer \(accessToken!)" {
                 // Removing headers from a request is not case insensitive
                 _mutableRequest.setValue(nil, forHTTPHeaderField: "Authorization")
                 _mutableRequest.setValue(nil, forHTTPHeaderField: "authorization")

--- a/SuperTokensIOS/Classes/Version.swift
+++ b/SuperTokensIOS/Classes/Version.swift
@@ -9,5 +9,5 @@ import Foundation
 
 internal class Version {
     static let supported_fdi: [String] = ["1.16"]
-    static let sdkVersion = "0.2.2"
+    static let sdkVersion = "0.2.3"
 }

--- a/testHelpers/server/index.js
+++ b/testHelpers/server/index.js
@@ -525,6 +525,15 @@ app.post("/logout-alt", async (req, res) => {
         .json({});
 });
 
+app.get("/base-custom-auth", async (req, res) => {
+    let header = req.headers["authorization"];
+    if (header === "Bearer myOwnHeHe") {
+        return res.status(200).json({message: "OK"});
+    } else {
+        return res.status(500).json({message: "Bad auth header"});
+    }
+})
+
 app.use("*", async (req, res, next) => {
     res.status(404).send();
 });


### PR DESCRIPTION
## Summary of change
Changes interception logic when adding the authorisation bearer token in the headers

## Related issues
- 

## Test Plan
New tests added

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [x] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...