### PR TITLE
update headers to be lowercased before comparing to constants

### DIFF
--- a/SuperTokensIOS/Classes/Utils.swift
+++ b/SuperTokensIOS/Classes/Utils.swift
@@ -262,11 +262,11 @@ internal class Utils {
     }
     
     internal static func saveTokenFromHeaders(httpResponse: HTTPURLResponse) {
-        guard let rawHeaderFields: [String: String] = httpResponse.allHeaderFields as? [String: String] else {
+        guard var headerFields: [String: String] = httpResponse.allHeaderFields as? [String: String] else {
             return
         }
 
-        let headerFields = rawHeaderFields.map{key,value in (key.lowercased(), value)}
+        headerFields.lowerCaseKeys()
         
         if let refreshToken: String = headerFields[SuperTokensConstants.refreshTokenHeaderKey] {
             Utils.setToken(tokenType: .refresh, value: refreshToken)

--- a/SuperTokensIOS/Classes/Utils.swift
+++ b/SuperTokensIOS/Classes/Utils.swift
@@ -262,9 +262,11 @@ internal class Utils {
     }
     
     internal static func saveTokenFromHeaders(httpResponse: HTTPURLResponse) {
-        guard let headerFields: [String: String] = httpResponse.allHeaderFields as? [String: String] else {
+        guard let rawHeaderFields: [String: String] = httpResponse.allHeaderFields as? [String: String] else {
             return
         }
+
+        let headerFields = rawHeaderFields.map{key,value in (key.lowercased(), value)}
         
         if let refreshToken: String = headerFields[SuperTokensConstants.refreshTokenHeaderKey] {
             Utils.setToken(tokenType: .refresh, value: refreshToken)

--- a/SuperTokensIOS/Classes/extensions/Dictionary.swift
+++ b/SuperTokensIOS/Classes/extensions/Dictionary.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Matt Murray on 9/8/23.
+//
+
+import Foundation
+
+extension Dictionary where Key: ExpressibleByStringLiteral {
+    public mutating func lowerCaseKeys() {
+        for key in self.keys {
+            self[String(describing: key).lowercased() as! Key] = self.removeValue(forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
## Summary of change
before this change the headers from the server (go in my case) had upper cased characters and since the constants that are used to handle different cases depending on those headers are all in lowercase it causes the token to not get saved to the UserDefaults and thus the user session is not persisted.

## Related issues
- [issue](https://github.com/supertokens/supertokens-ios/issues/49)


## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [ ] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [x] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [x] add the code that maps the headers as lowercase
