### PR TITLE
fix: remove redundant remove tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-07-12
+
+### Changes
+
+- Removed redundant calls to `removeToken`
+
 ## [0.4.0] - 2024-06-05
 
 ### Changes

--- a/SuperTokensIOS.podspec
+++ b/SuperTokensIOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SuperTokensIOS'
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.summary          = 'SuperTokens SDK for using login and session management functionality in iOS apps'
 
 # This description is used to generate tags and improve search results.

--- a/SuperTokensIOS/Classes/FrontToken.swift
+++ b/SuperTokensIOS/Classes/FrontToken.swift
@@ -99,6 +99,7 @@ internal class FrontToken {
     }
     
     static func removeToken() {
+        AntiCSRF.removeToken()
         let executionSemaphore = DispatchSemaphore(value: 0)
         
         readWriteDispatchQueue.async(flags: .barrier) {

--- a/SuperTokensIOS/Classes/SuperTokensURLProtocol.swift
+++ b/SuperTokensIOS/Classes/SuperTokensURLProtocol.swift
@@ -144,9 +144,7 @@ public class SuperTokensURLProtocol: URLProtocol {
                         if unauthResponse.status == .RETRY {
                             self.requestForRetry = mutableRequest
                             self.makeRequest()
-                        } else {
-                            SuperTokensURLProtocol.clearTokensIfRequired()
-                            
+                        } else {                            
                             if unauthResponse.error != nil {
                                 self.resolveToUser(data: nil, response: nil, error: unauthResponse.error)
                             } else {
@@ -154,13 +152,10 @@ public class SuperTokensURLProtocol: URLProtocol {
                             }
                         }
                     })
-                } else {
-                    SuperTokensURLProtocol.clearTokensIfRequired()
-                    
+                } else {                    
                     self.resolveToUser(data: data, response: response, error: error)
                 }
             } else {
-                SuperTokensURLProtocol.clearTokensIfRequired()
                 self.resolveToUser(data: data, response: response, error: error)
             }
         }).resume()
@@ -249,8 +244,6 @@ public class SuperTokensURLProtocol: URLProtocol {
                         frontTokenheaderFromResponse: frontTokenInHeaders == nil ? "remove" : frontTokenInHeaders!
                     )
                     
-                    SuperTokensURLProtocol.clearTokensIfRequired()
-                    
                     if httpResponse.statusCode >= 300 {
                         semaphore.signal()
                         callback(UnauthorisedResponse(status: UnauthorisedResponse.UnauthorisedStatus.API_ERROR, error: SuperTokensError.apiError(message: "Refresh API returned with status code: \(httpResponse.statusCode)")))
@@ -276,7 +269,6 @@ public class SuperTokensURLProtocol: URLProtocol {
                     SuperTokens.config!.eventHandler(.REFRESH_SESSION)
                     callback(UnauthorisedResponse(status: UnauthorisedResponse.UnauthorisedStatus.RETRY))
                 } else {
-                    SuperTokensURLProtocol.clearTokensIfRequired()
                     semaphore.signal()
                     callback(UnauthorisedResponse(status: UnauthorisedResponse.UnauthorisedStatus.API_ERROR, error: error))
                 }
@@ -288,14 +280,5 @@ public class SuperTokensURLProtocol: URLProtocol {
     
     public override func stopLoading() {
         // Do nothing, this is required to be implemented
-    }
-    
-    static func clearTokensIfRequired() {
-        let preRequestLocalSessionState = Utils.getLocalSessionState()
-        
-        if preRequestLocalSessionState.status == .NOT_EXISTS {
-            AntiCSRF.removeToken()
-            FrontToken.removeToken()
-        }
     }
 }

--- a/SuperTokensIOS/Classes/Version.swift
+++ b/SuperTokensIOS/Classes/Version.swift
@@ -9,5 +9,5 @@ import Foundation
 
 internal class Version {
     static let supported_fdi: [String] = ["1.16", "1.17", "1.18", "1.19", "2.0", "3.0"]
-    static let sdkVersion = "0.4.0"
+    static let sdkVersion = "0.4.1"
 }


### PR DESCRIPTION
## Summary of change

fix: remove redundant removeToken calls

## Related issues
- https://github.com/supertokens/supertokens-website/pull/265
- https://github.com/supertokens/supertokens-react-native/pull/127
- https://github.com/supertokens/supertokens-android/pull/75
- https://github.com/supertokens/supertokens-flutter/pull/61
- https://github.com/supertokens/supertokens-ios/pull/67

## Test Plan
Existing tests should cover this and keep working

## Documentation changes
N/A


## Checklist for important updates
- [x] Changelog has been updated
- [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [x] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
