### PR TITLE
ci: fix bad cpu type error in circleci tests

### DIFF
--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -18,6 +18,9 @@ jobs:
       fdi-version:
         type: string
     steps:
+      - run:
+        name: Install Rosetta translation environment on Apple Silicon Mac
+        command: softwareupdate --install-rosetta --agree-to-license
       - run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/ # This makes npm use http instead of ssh (required for node 16)
       - checkout
       - run: cd ../ && curl -L -o java.tar.gz "https://drive.usercontent.google.com/download?id=1zFjmXJFYEYw1bhPIZ0H2Q3oSy_HRCEQk&export=download&authuser=0&confirm=t&uuid=9563b3be-1e99-4293-a38c-001ea7cb2c37&at=APZUnTVgTPkWenZvgghQeFST-Yxk%3A1710776389213"


### PR DESCRIPTION
## Summary of change
ci: fix bad cpu type error in circleci tests

https://support.circleci.com/hc/en-us/articles/21521502906267-Why-am-I-seeing-Bad-CPU-type-in-executable-errors-when-running-CircleCI-Builds-on-Apple-Silicon#:~:text=Certain%20built%20binaries%20meant%20for,the%20following%20during%20CircleCI%20builds.&text=The%20%22Bad%20CPU%20type%20in,such%20as%20an%20M1%20Mac.

## Related issues
- https://app.circleci.com/pipelines/github/supertokens/supertokens-ios/440/workflows/3b0bd5c0-8533-4d6f-a137-f18079a320cf

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `SuperTokensIOS/Classes/Version.swift`
- [ ] Changes to the version if needed
   - In `SuperTokensIOS/Classes/Version.swift`
   - In `SuperTokensIOS.podspec`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
